### PR TITLE
[BUGFIX] Make site configuration overrides TYPO3 v11 compatible

### DIFF
--- a/Configuration/SiteConfiguration/Overrides/site.php
+++ b/Configuration/SiteConfiguration/Overrides/site.php
@@ -19,20 +19,29 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-$GLOBALS['SiteConfiguration']['site']['columns']['sitemap_robots_inject'] = [
-    'label' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.label',
-    'description' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.description',
-    'config' => [
-        'type' => 'check',
-        'renderType' => 'checkboxLabeledToggle',
-        'items' => [
-            [
-                'label' => '',
-                'labelChecked' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.item.checked',
-                'labelUnchecked' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.item.unchecked',
+(static function () {
+    if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() >= 12) {
+        $labelKey = 'label';
+    } else {
+        // @todo Remove once support for TYPO3 v11 is dropped
+        $labelKey = 0;
+    }
+
+    $GLOBALS['SiteConfiguration']['site']['columns']['sitemap_robots_inject'] = [
+        'label' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.label',
+        'description' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.description',
+        'config' => [
+            'type' => 'check',
+            'renderType' => 'checkboxLabeledToggle',
+            'items' => [
+                [
+                    $labelKey => '',
+                    'labelChecked' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.item.checked',
+                    'labelUnchecked' => 'LLL:EXT:sitemap_robots/Resources/Private/Language/locallang_db.xlf:site.sitemap_robots_inject.item.unchecked',
+                ],
             ],
         ],
-    ],
-];
+    ];
 
-$GLOBALS['SiteConfiguration']['site']['palettes']['xml_sitemap']['showitem'] .= ', --linebreak--, sitemap_robots_inject';
+    $GLOBALS['SiteConfiguration']['site']['palettes']['xml_sitemap']['showitem'] .= ', --linebreak--, sitemap_robots_inject';
+})();


### PR DESCRIPTION
This PR fixes site configuration overrides to be compatible with TYPO3 v11. This is required because TYPO3 v12 introduced array keys for checkbox items, whereas TYPO3 v11 still resides on numeric keys.