### PR TITLE
[TASK] Require PHPUnit >= 10.1 and migrate configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 	},
 	"require-dev": {
 		"eliashaeussler/transient-logger": "^1.0",
-		"phpunit/phpcov": "^8.2 || ^9.0 || ^10.0",
+		"phpunit/phpcov": "^9.0 || ^10.0",
+		"phpunit/phpunit": "^10.1 || ^11.0",
 		"typo3/cms-seo": "~11.5.19 || ~12.4.0 || ~13.1.0",
 		"typo3/testing-framework": "^7.0.2 || ^8.0.9"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c8a39b663651b670ebd21d0d1f43c04",
+    "content-hash": "40fdd0e0ddce310b987178ab97ab06ad",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/phpunit.functional.xml
+++ b/phpunit.functional.xml
@@ -6,9 +6,6 @@
          xsi:noNamespaceSchemaLocation=".Build/vendor/phpunit/phpunit/phpunit.xsd"
 >
     <coverage>
-        <include>
-            <directory suffix=".php">Classes</directory>
-        </include>
         <report>
             <php outputFile=".Build/coverage/php/functional.cov"/>
             <html outputDirectory=".Build/coverage/html/functional/"/>
@@ -23,4 +20,9 @@
     <logging>
         <junit outputFile=".Build/coverage/junit/functional.xml"/>
     </logging>
+    <source>
+        <include>
+            <directory>Classes</directory>
+        </include>
+    </source>
 </phpunit>

--- a/phpunit.unit.xml
+++ b/phpunit.unit.xml
@@ -6,9 +6,6 @@
          xsi:noNamespaceSchemaLocation=".Build/vendor/phpunit/phpunit/phpunit.xsd"
 >
     <coverage>
-        <include>
-            <directory suffix=".php">Classes</directory>
-        </include>
         <report>
             <php outputFile=".Build/coverage/php/unit.cov"/>
             <html outputDirectory=".Build/coverage/html/unit/"/>
@@ -23,4 +20,9 @@
     <logging>
         <junit outputFile=".Build/coverage/junit/unit.xml"/>
     </logging>
+    <source>
+        <include>
+            <directory>Classes</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
This PR adds an explicit requirement for PHPUnit >= 10.1 and migrates the existing configuration files.