### PR TITLE
[DOCS] Migrate containers to cards

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -41,59 +41,39 @@ local files.
 
 ----
 
-..  container:: row m-0 p-0
+..  card-grid::
+    :columns: 1
+    :columns-md: 2
+    :gap: 4
+    :card-height: 100
 
-    ..  container:: col-12 col-md-6 pl-0 pr-0 pr-md-3 pt-3 m-0
+    ..  card::  Introduction
 
-        ..  container:: card px-0 h-100
+        A quick overview about the main features provided by this extension.
 
-            ..  rst-class:: card-header h3
+        ..  card-footer::   :ref:`Learn more about this extension <introduction>`
+            :button-style: btn btn-secondary stretched-link
 
-                ..  rubric:: :ref:`introduction`
+    ..  card::  Installation
 
-            ..  container:: card-body
+        Instructions on how to install this extension and which TYPO3 and PHP versions are currently supported.
 
-                A quick overview about the main features provided
-                by this extension.
+        ..  card-footer::   :ref:`Getting started <installation>`
+            :button-style: btn btn-secondary stretched-link
 
-    ..  container:: col-12 col-md-6 pl-0 pr-0 pr-md-3 pt-3 m-0
+    ..  card::  Configuration
 
-        ..  container:: card px-0 h-100
+        Learn how to configure the extension in order to enable the provided features.
 
-            ..  rst-class:: card-header h3
+        ..  card-footer::   :ref:`View configuration options <configuration>`
+            :button-style: btn btn-secondary stretched-link
 
-                ..  rubric:: :ref:`installation`
+    ..  card::  Usage
 
-            ..  container:: card-body
+        This section describes how to use this extension in your application to enhance :file:`robots.txt`.
 
-                Instructions on how to install this extension and
-                which TYPO3 and PHP versions are currently supported.
-
-    ..  container:: col-12 col-md-6 pl-0 pr-0 pr-md-3 pt-3 m-0
-
-        ..  container:: card px-0 h-100
-
-            ..  rst-class:: card-header h3
-
-                ..  rubric:: :ref:`configuration`
-
-            ..  container:: card-body
-
-                Learn how to configure the extension in order to
-                enable the provided features.
-
-    ..  container:: col-12 col-md-6 pl-0 pr-0 pr-md-3 pt-3 m-0
-
-        ..  container:: card px-0 h-100
-
-            ..  rst-class:: card-header h3
-
-                ..  rubric:: :ref:`usage`
-
-            ..  container:: card-body
-
-                This section describes how to use this extension in
-                your application to enhance :file:`robots.txt`.
+        ..  card-footer::   :ref:`Learn how to use this extension <usage>`
+            :button-style: btn btn-secondary stretched-link
 
 ..  toctree::
     :hidden:


### PR DESCRIPTION
This PR migrates the previously used container elements to fresh new cards on the documentation homepage.