### PR TITLE
[BUGFIX] Ignore site language when enhancing robots.txt with sitemap

### DIFF
--- a/Classes/Middleware/RobotsTxtSitemapHandler.php
+++ b/Classes/Middleware/RobotsTxtSitemapHandler.php
@@ -50,7 +50,6 @@ final class RobotsTxtSitemapHandler implements Server\MiddlewareInterface
         Server\RequestHandlerInterface $handler,
     ): Message\ResponseInterface {
         $site = $request->getAttribute('site');
-        $siteLanguage = $request->getAttribute('language');
         $path = ltrim($request->getUri()->getPath(), '/');
 
         // Early return if site is not available
@@ -66,11 +65,6 @@ final class RobotsTxtSitemapHandler implements Server\MiddlewareInterface
         // Early return if robots.txt is not requested
         if ($path !== 'robots.txt') {
             return $handler->handle($request);
-        }
-
-        // Use default site language if language was not resolved
-        if (!($siteLanguage instanceof Core\Site\Entity\SiteLanguage)) {
-            $siteLanguage = $site->getDefaultLanguage();
         }
 
         // Resolve path to local robots.txt file
@@ -89,7 +83,7 @@ final class RobotsTxtSitemapHandler implements Server\MiddlewareInterface
         }
 
         try {
-            $this->enhancer->enhanceWithSitemaps($response->getBody(), $site, $siteLanguage);
+            $this->enhancer->enhanceWithSitemaps($response->getBody(), $site);
         } catch (Typo3SitemapLocator\Exception\Exception $exception) {
             $this->logger->warning(
                 'Unable to inject XML sitemaps into robots.txt at {url}.',

--- a/Classes/Resource/RobotsTxtEnhancer.php
+++ b/Classes/Resource/RobotsTxtEnhancer.php
@@ -46,9 +46,8 @@ final class RobotsTxtEnhancer
     public function enhanceWithSitemaps(
         Message\StreamInterface $robotsTxt,
         Core\Site\Entity\Site $site,
-        Core\Site\Entity\SiteLanguage $siteLanguage,
     ): void {
-        $sitemaps = $this->sitemapLocator->locateBySite($site, $siteLanguage);
+        $sitemaps = $this->sitemapLocator->locateBySite($site);
 
         // Go to end of file stream
         $robotsTxt->seek(0, SEEK_END);

--- a/Tests/Functional/Middleware/RobotsTxtSitemapHandlerTest.php
+++ b/Tests/Functional/Middleware/RobotsTxtSitemapHandlerTest.php
@@ -192,7 +192,7 @@ TXT,
     /**
      * @test
      */
-    public function processInjectsLocatedSitemapsOfGivenSiteLanguage(): void
+    public function processIgnoresSiteLanguageWhenEnhancingRobotsTxt(): void
     {
         $this->requestFactory->handler->append(new Core\Http\Response());
 
@@ -200,8 +200,7 @@ TXT,
 
         $actual = $this->subject->process($request, $this->handler);
 
-        self::assertStringNotContainsString(self::getExpectedContent(), (string)$actual->getBody());
-        self::assertStringContainsString(self::getExpectedContent('de'), (string)$actual->getBody());
+        self::assertStringContainsString(self::getExpectedContent(), (string)$actual->getBody());
     }
 
     /**

--- a/Tests/Functional/Resource/RobotsTxtEnhancerTest.php
+++ b/Tests/Functional/Resource/RobotsTxtEnhancerTest.php
@@ -90,7 +90,7 @@ TXT);
 
         $this->expectException(Typo3SitemapLocator\Exception\BaseUrlIsNotSupported::class);
 
-        $this->subject->enhanceWithSitemaps($this->robotsTxt, $site, $site->getDefaultLanguage());
+        $this->subject->enhanceWithSitemaps($this->robotsTxt, $site);
     }
 
     /**
@@ -100,7 +100,7 @@ TXT);
     {
         $this->requestFactory->handler->append(new Core\Http\Response());
 
-        $this->subject->enhanceWithSitemaps($this->robotsTxt, $this->site, $this->site->getDefaultLanguage());
+        $this->subject->enhanceWithSitemaps($this->robotsTxt, $this->site);
 
         self::assertSame(
             <<<TXT


### PR DESCRIPTION
Since the `robots.txt` must be placed at the root of a website (as stated [here](https://www.robotstxt.org/robotstxt.html#:~:text=Where%20to%20put,your%20web%20server.)), there's no need to pass a site language to the `RobotsTxtEnhancer`. Hence, the additional parameter is removed with this PR.