### PR TITLE
[BUGFIX] Avoid deprecations with TYPO3 v14 in classic mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,9 @@
 	},
 	"extra": {
 		"typo3/cms": {
+			"Package": {
+				"providesPackages": {}
+			},
 			"extension-key": "sitemap_robots",
 			"web-dir": ".Build/web"
 		},

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
 				"providesPackages": {}
 			},
 			"extension-key": "sitemap_robots",
+			"version": "1.3.1",
 			"web-dir": ".Build/web"
 		},
 		"version-bumper": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f54a2f3f55b2c2b54a30461b1d169183",
+    "content-hash": "2724433aa9aaf16917c11965b368e7f9",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e454e9d7abaf3c3d4006027809cd5f6e",
+    "content-hash": "f54a2f3f55b2c2b54a30461b1d169183",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the extension version to 1.3.1.
  * Added package provisioning metadata for improved compatibility with TYPO3 package handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->